### PR TITLE
Use JSON API format instead of PHP

### DIFF
--- a/SectionStore.php
+++ b/SectionStore.php
@@ -37,10 +37,10 @@ class SectionStore
 	{
 		/* Calls MW API */
 		$pageForUrl = rawurlencode($page);
-        $req = curl_init("https://" . $this->wikiHost . "/w/api.php?action=parse&prop=sections&page=$pageForUrl&format=php");
+        $req = curl_init("https://" . $this->wikiHost . "/w/api.php?action=parse&prop=sections&page=$pageForUrl&format=json");
         curl_setopt($req, CURLOPT_RETURNTRANSFER, 1);
         $ser = curl_exec($req);
-        $unser = unserialize($ser);
+        $unser = json_decode($ser, TRUE);
 		
 		if(isset($unser['error']) && $unser['error']['code'] == 'missingtitle') {
 			$this->arr[$page] = FALSE;

--- a/index.php
+++ b/index.php
@@ -231,11 +231,11 @@
 			throw new Exception('Max. API call limit exceeded (' . MAX_API_CALLS . ')', API_EXC);
 	
 		$pageForUrl = rawurlencode($page);
-		$url = "https://$wikiHost/w/api.php?action=query&prop=revisions&generator=backlinks&gbltitle=$pageForUrl$queryContinue&rvprop=content&format=php";
+		$url = "https://$wikiHost/w/api.php?action=query&prop=revisions&generator=backlinks&gbltitle=$pageForUrl$queryContinue&rvprop=content&format=json";
 		$req = curl_init($url);
 		curl_setopt($req, CURLOPT_RETURNTRANSFER, 1);
 		$ser = curl_exec($req);
-		$unser = unserialize($ser);
+		$unser = json_decode($ser, TRUE);
 		$references = $unser['query']['pages'];
 		// Recursive function for query-continue
 		if(isset($unser['query-continue']))
@@ -275,10 +275,10 @@
 		if($followRedirects)
 			$redirects='&redirects'; 
 		$pageForUrl = rawurlencode($page);
-		$req = curl_init("https://$wikiHost/w/api.php?action=query&prop=revisions&titles=$pageForUrl&rvprop=content$redirects&format=php");
+		$req = curl_init("https://$wikiHost/w/api.php?action=query&prop=revisions&titles=$pageForUrl&rvprop=content$redirects&format=json");
 		curl_setopt($req, CURLOPT_RETURNTRANSFER, 1);
 		$ser = curl_exec($req);
-		$unser = unserialize($ser);
+		$unser = json_decode($ser, TRUE);
 		$singlePage = array_shift($unser['query']['pages']);
 		if(isset($singlePage['missing'])) {
 			return FALSE;


### PR DESCRIPTION
https://www.mediawiki.org/wiki/?diff=1345565

> **All new API users are recommended to use JSON only**. We especially recommend clients written in PHP to **avoid using the PHP format** because it's fundamentally insecure.
