### PR TITLE
Change Tool Labs to Toolforge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [MediaWiki documentation](https://www.mediawiki.org/wiki/Help:Links) for
 
 ## Hosting
 
-The tool is currently hosted on [Wikimedia Tool Labs](https://toolforge.org/) at the following address:
+The tool is currently hosted on [Wikimedia Toolforge](https://toolforge.org/) at the following address:
 https://section-links.toolforge.org/
 
 It was previously hosted on [Wikimedia Toolserver](https://meta.wikimedia.org/wiki/Toolserver).

--- a/config.default.php
+++ b/config.default.php
@@ -2,7 +2,7 @@
 
 // Please don't edit this file! Copy it as config.php and then edit it.
 
-// PRODUCTION configuration for WMF Tool Labs.
+// PRODUCTION configuration for WMF Toolforge.
 
 // Imports DB_USER, DB_PASSWORD credentials from external file.
 require_once("../external_includes/mysql_pw.inc");

--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@
 				</a>
 				<div class="media-body">
 					<h1>Section Links<br />
-					<small>Wikimedia Tool Labs — Pietrodn's tools.</small>
+					<small>Wikimedia Toolforgr — Pietrodn's tools.</small>
 					</h1>
 				</div>
 			</div>
@@ -292,7 +292,7 @@
 
 	<div id="footer">
 		<div class="container">
-			<a href="//toolforge.org/"><img id="footer-icon" src="//tools-static.wmflabs.org/static/logos/powered-by-tool-labs.png" title="Powered by Wikimedia Tool Labs" alt="Powered by Wikimedia Tool Labs" /></a>
+			<a href="//toolforge.org/"><img id="footer-icon" src="//tools-static.wmflabs.org/static/logos/powered-by-tool-labs.png" title="Powered by Wikimedia Toolforge" alt="Powered by Wikimedia Tool Labs" /></a>
 			<p class="text-muted credit">
 			Made by <a href="//wikitech.wikimedia.org/wiki/User:Pietrodn">Pietro De Nicolao (Pietrodn)</a>.
 			Licensed under the

--- a/index.php
+++ b/index.php
@@ -61,7 +61,7 @@
 				</a>
 				<div class="media-body">
 					<h1>Section Links<br />
-					<small>Wikimedia Toolforgr — Pietrodn's tools.</small>
+					<small>Wikimedia Toolforge — Pietrodn's tools.</small>
 					</h1>
 				</div>
 			</div>

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<link rel="shortcut icon" href="/favicon.ico" />
 
-		<title>Section Links - Wikimedia Tool Labs</title>
+		<title>Section Links - Wikimedia Toolforge</title>
 		<link href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" rel="stylesheet">
         <link href="pietrodn.css" rel="stylesheet">
 	</head>
@@ -40,7 +40,7 @@
 			<span class="icon-bar"></span>
 			<span class="icon-bar"></span>
 		  </button>
-		  <a class="navbar-brand" href="//toolforge.org/">WMF Tool Labs</a>
+		  <a class="navbar-brand" href="//toolforge.org/">WMF Toolforge</a>
 		</div>
 		<div class="navbar-collapse collapse">
 		  <ul class="nav navbar-nav">


### PR DESCRIPTION
Toolforge is the current name for Tool Labs